### PR TITLE
Garbage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,7 @@
 [![Gitter](https://badges.gitter.im/zsh-vi-more/community.svg)](https://gitter.im/zsh-vi-more/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Matrix](https://img.shields.io/matrix/zsh-vi-more_community:gitter.im)](https://matrix.to/#/#zsh-vi-more_community:gitter.im)
 
+`:help substitute`
+To see usage.
+
 [![asciicast](https://asciinema.org/a/MD4j4uZ4j5K0FF5YBDI8BR7WV.svg)](https://asciinema.org/a/MD4j4uZ4j5K0FF5YBDI8BR7WV)

--- a/functions/ex-command-help
+++ b/functions/ex-command-help
@@ -1,8 +1,36 @@
-case $1 in
+# vim:ft=zsh
+function -zle-widget-help() {
+  local widget=''
+  if [[ ${(Mk)widgets:#$1} ]]; then
+      command -v ul >/dev/null || { print "\nInstall util-linux" ; return }
+      widget="$(command awk -v pat="$1" 'BEGIN {
+  esc = "\033\\[1m"
+  regex = "(" esc ")?" pat
+  printing = 0
+}
+{
+  if (!printing && $0 ~ regex) {
+    printing = 1
+  } else if (printing && $0 ~ /^ {7,8}[^ ]/) {
+    exit
+  }
+  if (printing) print}' < <(man zshzle | ul))"
 
-(|:)s(|ubstitute))
-print -Pr '
-:%Bs[ubstitute]%b%F{blue}/%f%F{red}pattern%f%F{blue}/%f%F{red}replacement%f[%F{blue}/%f%F{green}flags%f]
+    if [ ${#widget} -ge 2 ]; then
+      print "\n$widget"
+      printf '%0.s\n' {1..$(( ${#${(f)widget}} + 4 ))}
+    else
+      print "\n$0: $1 is a Non-Native zle widget.\n$(whence -v "$(echo ${widgets[$1]:5})" 2>/dev/null)
+      "
+      printf '%0.s\n' {1..$(( ${#${(f)widget}} + 4 ))}
+    fi
+  fi
+}
+
+case $1 in
+  (|:)s(|ubstitute))
+    print -Pr '
+    :%Bs[ubstitute]%b%F{blue}/%f%F{red}pattern%f%F{blue}/%f%F{red}replacement%f[%F{blue}/%f%F{green}flags%f]
 	The %F{blue}/pattern delimiter/%f can be any non-alphanumeric character other than %B&%b.
 	Any \$parameters, \$(command substitutions), etc. in %F{red}replacment%f are expanded.
 	In all %F{green}mode%fs except %F{green}fixed%f, the %B&%b character will be replaced with the whole
@@ -19,19 +47,12 @@ print -Pr '
 	  %Bi%b: (PCRE|glob only) Replace %Bcase-insensitively%b
 	  %BI%b: Replace %Bcase-sensitively%b
 	  %Bp%b: Treat %F{red}pattern%f as a %BPCRE%b.
-' | less -R
-zle -R
-zle redisplay
-;;
 
-*)
-if [[ ${(Mk)widgets:#$1} ]]; then
-	zle -M "$0: $1 is a zle widget. See zshzle(1)"
-else
-	zle -M "$0: Unknown command: $1"
-fi
 
+
+
+    '
+  ;;
+  *) -zle-widget-help $1
+  ;;
 esac
-
-
-# vim:ft=zsh


### PR DESCRIPTION
This PR started off because I couldn't get any part of the help command to work.
With any use of `zle -M` either not showing anything, or it flashes in the prompt for a split second before disappearing..
After spending far too much time experimenting. I think its due to the `zle -M message` being called in when you're in viins mode. 
But after ex-command-help finishes, the active keymap switches to vicmd, and wipes the `zle -M` message.

I also found it VERY painful finding a reliable way to print in the shell. With all sorts of strange behaviors, like printed lines being arbitrarily cut off.
I thought you may have been running into the same issue from seeing the `print -Pr 'help page'| less -R` line.

For this PR I expanded the `:help` to work for the default zle widgets and if its a custom widget it will try and find the source file.
In coming up with this garbage, I just didn't know enough about how zle works. So I have hacky nonsense like this  `printf '%0.s\n' {1..$(( ${#${(f)widget}} + 4 ))}` to avoid cases where lines would get cut off.

Anyway I spent far too much time on this not to put it in a PR. Hopefully it can be of _some_ use.
